### PR TITLE
Add node for ugreen dongle, alloywifi is now alloy

### DIFF
--- a/data_bags/config_network/maxlab.json
+++ b/data_bags/config_network/maxlab.json
@@ -300,8 +300,17 @@
           "base": "maxlab_sarko",
           "mac_address": "44:85:00:4D:BF:B6"
         },
+        "52": {
+          "node_name": "ugreen",
+          "description": "Ugreen usb-c adapter for laptops",
+          "type": "node",
+          "group": "dongle",
+          "os:": "dongle",
+          "base": "dongle",
+          "mac_address": "c8:a3:62:67:48:61"
+        },
         "53": {
-          "node_name": "metalwifi",
+          "node_name": "metal",
           "description": "HP Elitebook 840 G8 integrated WIFI",
           "type": "node",
           "group": "laptop",


### PR DESCRIPTION
For newer usb-c laptops, use the node name as 'node' and the dock name
  as 'nodedock'. Ex: alloy, alloydock and metal, metaldock.

* Fixing alloywifi to alloy for this standard

* Creating new node .52 as a 'dongle' for the UGREEN usb-c to ethernet dongle that will be used with metal, alloy and mac for work